### PR TITLE
Add Hangul syllable decomposition support for Korean text input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "calloop",
  "clap",
  "env_logger",
+ "hangul",
  "libc",
  "log",
  "pkg-config",
@@ -431,6 +432,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "hangul"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121f689bdaee71d90f31e8aeb7a6794a5230504b25ab8b28932433443509aead"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ rustix = { version = "1", features = ["fs", "event"] }
 log = "0.4"
 env_logger = "0.11"
 
+# Korean Hangul syllable decomposition
+hangul = "0.1.3"
+
 # Python bindings (optional)
 pyo3 = { version = "0.27", features = ["extension-module"], optional = true }
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for typing Korean Hangul text by implementing syllable decomposition and Jamo character conversion. When a Hangul syllable cannot be directly typed via keycode lookup, it is decomposed into individual Jamo (consonants and vowels) that are then typed sequentially, allowing the IME to recompose them into the original syllable.

## Key Changes

- **Hangul syllable decomposition**: Hangul syllables (U+AC00\~U+D7A3) are decomposed into their constituent Jamo using the `hangul` crate's `HangulExt` trait
- **Complex Jongseong handling**: Complex trailing consonants (11 combinations like ㄳ, ㄺ, etc.) that may not have direct keycodes are further decomposed into two simple consonants
- **Hangul Jamo conversion**: Characters in the Hangul Jamo block (U+1100\~U+11FF) are converted to Compatibility Jamo (U+3131~U+3163) since XKB Korean keymaps use Compatibility Jamo keysyms
- **Refactored character typing**: Split `type_char()` into `type_char_direct()` (direct keycode lookup) and `type_char()` (with fallback decomposition), allowing graceful degradation when characters aren't found
- **Comprehensive test coverage**: Added tests for syllable decomposition, complex Jongseong decomposition, and Jamo-to-Compatibility-Jamo conversion

## Implementation Details

- Added three lookup tables (`CHOSEONG_TO_COMPAT`, `JUNGSEONG_TO_COMPAT`, `JONGSEONG_TO_COMPAT`) for efficient Jamo conversion
- The decomposition strategy uses a fallback approach: attempt direct typing first, then decompose only if `CharNotFound` error occurs
- Complex Jongseong decomposition is handled recursively within the character typing logic
- Added `hangul = "0.1.3"` dependency to `Cargo.toml` for syllable decomposition utilities

https://claude.ai/code/session_01DehdMEJ1HxGTc8Wsqxgi67