### PR TITLE
Fix non-Latin character lookup in keymap (#8)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,20 +324,16 @@ fn search_key_for_char(
 
 /// Convert an XKB keysym to a character
 fn keysym_to_char(keysym: u32) -> Option<char> {
-    if (0x20..=0x7e).contains(&keysym) {
-        return char::from_u32(keysym);
+    // Map XK_Return to '\n' so callers can pass "\n" to press Enter.
+    // xkb_keysym_to_utf32 returns '\r' (U+000D) for this keysym.
+    if keysym == 0xff0d {
+        return Some('\n');
     }
-    if (0xa0..=0xff).contains(&keysym) {
-        return char::from_u32(keysym);
-    }
-    if keysym >= 0x1000000 {
-        return char::from_u32(keysym - 0x1000000);
-    }
-    match keysym {
-        0xff0d => Some('\n'),
-        0xff09 => Some('\t'),
-        0x20 => Some(' '),
-        _ => None,
+    let codepoint = xkb::keysym_to_utf32(xkb::Keysym::new(keysym));
+    if codepoint == 0 {
+        None
+    } else {
+        char::from_u32(codepoint)
     }
 }
 
@@ -1460,6 +1456,31 @@ mod tests {
     #[test]
     fn test_keysym_to_char_unicode() {
         assert_eq!(keysym_to_char(0x1000000 + 0x00e9), Some('é'));
+    }
+
+    #[test]
+    fn test_keysym_to_char_cyrillic() {
+        // Cyrillic_PE / Cyrillic_pe — regression test for issue #8
+        assert_eq!(keysym_to_char(0x06f0), Some('П'));
+        assert_eq!(keysym_to_char(0x06d0), Some('п'));
+    }
+
+    #[test]
+    fn test_keysym_to_char_greek() {
+        // Greek_alpha → α, Greek_ALPHA → Α
+        assert_eq!(keysym_to_char(0x07e1), Some('α'));
+        assert_eq!(keysym_to_char(0x07c1), Some('Α'));
+    }
+
+    #[test]
+    fn test_keysym_to_char_special() {
+        assert_eq!(keysym_to_char(0xff0d), Some('\n')); // XK_Return → '\n'
+        assert_eq!(keysym_to_char(0xff09), Some('\t')); // XK_Tab
+    }
+
+    #[test]
+    fn test_keysym_to_char_unmapped() {
+        assert_eq!(keysym_to_char(0xffe1), None); // XK_Shift_L has no Unicode mapping
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace hand-rolled `keysym_to_char` ranges with libxkbcommon's `xkb_keysym_to_utf32`, fixing `Character not found in keymap` for Cyrillic, Greek, Hebrew, Arabic, Thai, Hangul, Latin Extended, and the legacy "Technical/Publishing/Special" blocks
- Preserve the explicit `XK_Return → '\n'` mapping (xkbcommon would map it to `'\r'`, which would silently break `eitype "\n"` for pressing Enter)
- Add regression tests for Cyrillic (the reported case in #8), Greek, Return-as-newline, and an unmapped non-character keysym

## Root cause
The previous implementation handled only three ranges:
- ASCII (0x20–0x7e)
- Latin-1 (0xa0–0xff)
- X11 direct-Unicode keysyms (≥ 0x01000000)

It returned `None` for every legacy keysym block, so `Cyrillic_PE` (0x06d0 = `П`) was not findable even when the Russian layout was correctly auto-detected. The reporter's logs in #8 show layout detection picked index 1 = Russian — the per-character lookup is what failed.

## Test plan
- [x] `cargo test --lib` (24 passed, including new keysym tests)
- [x] `cargo fmt --check`
- [x] Live reproduction with `[us+dvp, ru]` layout, `--layout-index 1 eitype "П"` — fails on `main`, succeeds on this branch

## Out of scope (separate follow-ups)
- Characters at level 3+ that need AltGr (`search_key_for_char` only signals shift)
- Dead-key composed characters (would need xkbcommon's compose API)
- CJK ideographs (typically routed through an IME, not the keymap)