### PR TITLE
fix: make EiType Send + Sync instead of unsendable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "eitype"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "ashpd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eitype"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "A wtype-like CLI tool and library for typing text using Emulated Input (EI) protocol on Wayland"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -241,6 +241,18 @@ typer, _ = EiType.connect_portal_with_token(saved_token)
 typer.type_text("No dialog this time!")
 ```
 
+## Thread Safety
+
+`EiType` is `Send` but not `Sync`. You can **move** an instance between threads —
+for example, create it on one thread and call it from a thread pool — but you must
+**not** call its methods from two threads concurrently.
+
+- **From Python**, this is automatic on standard CPython: the GIL serializes every
+  call. On a free-threaded (no-GIL) interpreter the GIL no longer protects you, so
+  wrap the instance in your own lock if more than one thread can reach it.
+- **From Rust**, serialize access yourself (e.g. behind a `Mutex`) when sharing an
+  instance across threads.
+
 ## Rust Library Usage
 
 Add to your `Cargo.toml`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "eitype"
-version = "0.2.1"
+version = "0.2.2"
 description = "Python bindings for eitype - type text on Wayland using the Emulated Input (EI) protocol"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/eitype/__init__.py
+++ b/python/eitype/__init__.py
@@ -118,6 +118,13 @@ class EiType:
         >>> typer = EiType.connect_portal()
         >>> typer.type_text("Hello!")
         >>> typer.close()  # Important: call close() before reconnecting
+
+    Thread safety:
+        An ``EiType`` instance may be used from a different thread than the one
+        that created it (e.g. a worker in a ``ThreadPoolExecutor``), but you must
+        not call its methods from two threads at the same time. On a standard
+        CPython interpreter the GIL serializes calls for you; on a free-threaded
+        (no-GIL) build, guard the instance with your own lock.
     """
 
     @staticmethod

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1366,11 +1366,8 @@ impl EiType {
             match &ks.keymap {
                 Some(keymap) => {
                     let key_match = find_keycode_for_char(ch, keymap, self.layout_index)?;
-                    let mod_keycodes = modifier_keycodes_for_match(
-                        keymap,
-                        &key_match,
-                        &self.keymap_mod_keycodes,
-                    );
+                    let mod_keycodes =
+                        modifier_keycodes_for_match(keymap, &key_match, &self.keymap_mod_keycodes);
                     Some((key_match.evdev_keycode, mod_keycodes))
                 }
                 None => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,18 @@
 //! // Press special keys
 //! typer.press_key("Return").unwrap();
 //! ```
+//!
+//! # Thread safety
+//!
+//! [`EiType`] is [`Send`] **and** [`Sync`]: it is safe to create it on one thread
+//! and use it from another (for example, a worker in a thread pool). Access to the
+//! underlying xkbcommon objects is serialized with an internal lock, so sharing an
+//! instance across threads is memory-safe and works the same on GIL-enabled and
+//! free-threaded interpreters.
+//!
+//! Note that the keystroke *stream* is not transactional: if two threads type on the
+//! same instance simultaneously their key events will interleave. Serialize at a
+//! higher level if you need coherent output.
 
 use log::{debug, error, info, trace, warn};
 use reis::ei::{self, handshake::ContextType, keyboard::KeyState};
@@ -25,7 +37,7 @@ use reis::event::{DeviceCapability, EiEvent};
 use std::collections::HashMap;
 use std::os::unix::net::UnixStream;
 use std::path::Path;
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use thiserror::Error;
 use xkbcommon::xkb;
@@ -923,14 +935,22 @@ fn connect_via_socket(path: &Path) -> Result<UnixStream, EiTypeError> {
 // Main EiType Struct
 // ============================================================================
 
-/// Main interface for typing text via EI protocol
-#[cfg_attr(feature = "python", pyclass(unsendable))]
+/// Main interface for typing text via EI protocol.
+///
+/// # Thread safety
+///
+/// `EiType` is `Send + Sync`: safe to create on one thread and use from another
+/// (e.g. a thread pool). The non-thread-safe xkbcommon objects are held behind an
+/// internal lock, so access is serialized automatically. See the crate-level docs
+/// for the one caveat (concurrent typing interleaves keystrokes).
+#[cfg_attr(feature = "python", pyclass)]
 pub struct EiType {
     connection: reis::event::Connection,
     device: reis::event::Device,
     keyboard: ei::Keyboard,
-    keymap: Option<xkb::Keymap>,
-    xkb_state: Option<xkb::State>,
+    /// xkb keymap + state, behind a lock so `EiType` can be `Send + Sync`
+    /// despite xkbcommon's non-atomic refcounting. See [`KeymapState`].
+    keymap: Mutex<KeymapState>,
     key_to_keycode: HashMap<String, u32>,
     /// Real-modifier name (e.g. "Mod5") -> evdev keycode that produces it,
     /// derived from the active keymap's modmap. Populated by `install_keymap`.
@@ -942,6 +962,37 @@ pub struct EiType {
     /// Track whether close() has been called to avoid double-close
     closed: bool,
 }
+
+/// The xkb keymap and state, which wrap xkbcommon C objects.
+///
+/// These are stored together behind an `EiType`-owned `Mutex` so that the rest of
+/// `EiType` can be `Send + Sync`. xkbcommon uses non-atomic reference counting, so
+/// the objects are not thread-safe on their own; keeping every access behind the
+/// lock guarantees they are never touched from two threads at once.
+#[derive(Default)]
+struct KeymapState {
+    keymap: Option<xkb::Keymap>,
+    xkb_state: Option<xkb::State>,
+}
+
+// SAFETY: `KeymapState` holds `xkb::Keymap`/`xkb::State`, which are `!Send` because
+// xkbcommon refcounts its C objects non-atomically. They are only ever reached
+// through `EiType::keymap` (a `Mutex`), so all access — including the final `Drop`
+// of these objects — is serialized and never concurrent. Under that invariant it is
+// sound to move them between threads, which is what `Send` asserts. We do not need
+// (or claim) `Sync` for `KeymapState`: `Mutex<KeymapState>` is `Sync` purely from
+// `KeymapState: Send`, and the lock is what provides the actual synchronization.
+unsafe impl Send for KeymapState {}
+
+// Compile-time guarantee that `EiType` is `Send + Sync`. PyO3 requires a (non-
+// `unsendable`) `#[pyclass]` to be `Send + Sync`; this is what lets the typer be
+// handed to a different thread (e.g. a `ThreadPoolExecutor` worker) instead of
+// panicking with "unsendable, but sent to another thread". If a future field
+// reintroduces `!Send`/`!Sync`-ness, this assertion fails to build.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<EiType>();
+};
 
 impl EiType {
     /// Connect via the XDG RemoteDesktop portal (simple version, no token management)
@@ -1070,8 +1121,7 @@ impl EiType {
             connection,
             device,
             keyboard,
-            keymap: None,
-            xkb_state: None,
+            keymap: Mutex::new(KeymapState::default()),
             key_to_keycode: build_key_to_keycode_map(),
             keymap_mod_keycodes: HashMap::new(),
             delay: Duration::from_millis(config.delay_ms),
@@ -1098,8 +1148,9 @@ impl EiType {
             "Resolved modifier keycodes from keymap: {:?}",
             self.keymap_mod_keycodes
         );
-        self.keymap = Some(keymap);
-        self.xkb_state = Some(state);
+        let ks = self.keymap.get_mut().unwrap_or_else(|e| e.into_inner());
+        ks.keymap = Some(keymap);
+        ks.xkb_state = Some(state);
     }
 
     fn setup_keymap(&mut self, config: &EiTypeConfig) -> Result<(), EiTypeError> {
@@ -1307,16 +1358,31 @@ impl EiType {
     fn type_char(&self, ch: char) -> Result<(), EiTypeError> {
         trace!("Typing character: {:?}", ch);
 
-        if let Some(keymap) = &self.keymap {
-            let key_match = find_keycode_for_char(ch, keymap, self.layout_index)?;
-            let mod_keycodes =
-                modifier_keycodes_for_match(keymap, &key_match, &self.keymap_mod_keycodes);
+        // Resolve the character to keycodes while holding the keymap lock, then
+        // release it before emitting any events — the press/release path never
+        // needs the keymap, so the lock scope stays as small as possible.
+        let resolved = {
+            let ks = self.keymap.lock().unwrap_or_else(|e| e.into_inner());
+            match &ks.keymap {
+                Some(keymap) => {
+                    let key_match = find_keycode_for_char(ch, keymap, self.layout_index)?;
+                    let mod_keycodes = modifier_keycodes_for_match(
+                        keymap,
+                        &key_match,
+                        &self.keymap_mod_keycodes,
+                    );
+                    Some((key_match.evdev_keycode, mod_keycodes))
+                }
+                None => None,
+            }
+        };
 
+        if let Some((evdev_keycode, mod_keycodes)) = resolved {
             for &mkc in &mod_keycodes {
                 self.press_key_internal(mkc)?;
             }
 
-            self.tap_key_internal(key_match.evdev_keycode)?;
+            self.tap_key_internal(evdev_keycode)?;
 
             for &mkc in mod_keycodes.iter().rev() {
                 self.release_key_internal(mkc)?;

--- a/tests/thread_safety.rs
+++ b/tests/thread_safety.rs
@@ -1,0 +1,43 @@
+//! Regression test for the `unsendable` panic.
+//!
+//! `EiType` must be `Send + Sync` so it can be created on one thread and used from
+//! another (for example, a worker in a `ThreadPoolExecutor`).
+//!
+//! Before the fix, `EiType` was `#[pyclass(unsendable)]`; PyO3 then panicked with
+//! "EiType is unsendable, but sent to another thread" whenever a cached typer was
+//! reused from a different worker thread than the one that created it. Because the
+//! panic surfaced in Python as `pyo3_runtime.PanicException` (a `BaseException`), it
+//! slipped past callers' `except Exception` handlers and silently dropped the text.
+
+use eitype::EiType;
+
+// Compile-time guarantee from a downstream crate's perspective — this is exactly
+// what the Python bindings and any other consumer rely on. If a future change makes
+// `EiType` `!Send`/`!Sync` again, this fails to build.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<EiType>();
+};
+
+/// Move a connected typer to another thread and type from it — the precise pattern
+/// that used to panic. Requires a Wayland desktop with EI support, so it is gated
+/// behind the same feature as the other integration tests.
+#[cfg(feature = "wayland-integration-tests")]
+#[test]
+fn test_type_from_a_different_thread() {
+    use eitype::EiTypeConfig;
+
+    let typer =
+        EiType::connect_portal(EiTypeConfig::default()).expect("Failed to connect to portal");
+
+    // Created on this thread, moved into and used from another. The `move` closure
+    // compiles only because `EiType: Send`, and the call itself would have tripped
+    // the `unsendable` thread-affinity assertion before the fix.
+    let handle = std::thread::spawn(move || {
+        typer
+            .type_text("Typed from a spawned thread - no unsendable panic.")
+            .expect("typing from another thread failed");
+    });
+
+    handle.join().expect("typing thread panicked");
+}


### PR DESCRIPTION
## Problem

`EiType` was declared `#[pyclass(unsendable)]`, which pins the object to the thread that created it. PyO3 then **panics** — `assertion failed: EiType is unsendable, but sent to another thread` — on any access from a different thread.

A Python caller that caches a typer and reuses it across a thread pool (e.g. a `ThreadPoolExecutor`) therefore hits this panic. Because PyO3 surfaces it as `pyo3_runtime.PanicException` (a `BaseException`, **not** `Exception`), it slips past normal `except Exception` handling: the typing call neither completes nor is recoverable, and the text is **silently dropped** with no error. It "works most of the time" only because the pool usually reuses the same worker thread.

## Fix

The only members that are genuinely not thread-safe are the xkbcommon `keymap`/`state`, which use non-atomic reference counting. Move them behind a `Mutex<KeymapState>` (with a localized `unsafe impl Send` justified by that lock) so the whole type becomes genuinely **`Send + Sync`**, and drop `unsendable`.

Because access is now serialized by a real lock rather than relying on the GIL, this is sound on GIL-enabled **and** free-threaded interpreters, and for the plain-Rust API. The lock scope in `type_char` is kept minimal — resolve keycodes under the lock, release it before emitting events.

## Contract (documented in crate docs, struct docs, README, Python docstring)

`EiType` is `Send + Sync`: safe to create on one thread and use from another (e.g. a thread-pool worker). Access is internally serialized, so sharing across threads is memory-safe. The one caveat: typing from two threads *simultaneously* will interleave keystrokes — serialize at a higher level if you need coherent output.

## Verification

- Builds with and without the `python` feature.
- 31 unit tests pass.
- Compile-time `assert_send_sync::<EiType>()` guard (fails the build if the type regresses).
- New `tests/thread_safety.rs`: downstream `Send + Sync` assertion plus a gated cross-thread typing test (the `move`-into-a-thread call site now compiles).
- clippy clean.